### PR TITLE
Form Helper: adding id atributtes for form inputs

### DIFF
--- a/monstra/helpers/form.php
+++ b/monstra/helpers/form.php
@@ -136,6 +136,9 @@
             
             // Set the input name
             $attributes['name'] = $name;
+            
+            // Set the input id
+            $attributes['id'] = (isset($attributes['id']))?$attributes['id']:$name;
 
             // Set the input value
             $attributes['value'] = $value;
@@ -286,6 +289,9 @@
             
             // Set the input name
             $attributes['name'] = $name;
+            
+            // Set the input id
+            $attributes['id'] = (isset($attributes['id']))?$attributes['id']:$name;
 
             return '<textarea'.Html::attributes($attributes).'>'.$body.'</textarea>';
         }
@@ -309,6 +315,9 @@
             
             // Set the input name
             $attributes['name'] = $name;
+            
+            // Set the input id
+            $attributes['id'] = (isset($attributes['id']))?$attributes['id']:$name;
             
             $options_output = '';
 


### PR DESCRIPTION
If label is clicked, form input assigned with label cannot be focused, because input has not "id" attribute.

``` php
Form::label('field_name', 'It is label').
Form::input('field_name', 'It is input')
```

**Before fix generates:**

``` html
<label for="field_name">It is label</label>
<input type="text" name="field_name" value="It is input"/>
```

**After fix generates:**

``` html
<label for="field_name">It is label</label>
<input type="text" id="field_name" name="field_name" value="It is input"/>
```
