### PR TITLE
Update index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -45,6 +45,9 @@ if (file_exists('install.php')) {
         if ((Session::exists('user_role')) and (Session::get('user_role') == 'admin' or Session::get('user_role') == 'editor')) {
             // Monstra show this page :)
         } else {
+            header('HTTP/1.1 503 Service Temporarily Unavailable');
+            header('Status: 503 Service Temporarily Unavailable');
+            header('Retry-After: 600');
             die (Text::toHtml(Option::get('maintenance_message')));
         }
     }


### PR DESCRIPTION
503 is the correct server response for "We're closed". If you substitute a normal HTML page saying "We're closed" and serve a 200 it's very likely to get indexed by Google.

If you give the Googlebot a 503, it will just go away and come back later without indexing what you give it.
