### PR TITLE
#295 Backup plugin: fix notification

### DIFF
--- a/plugins/box/backup/backup.admin.php
+++ b/plugins/box/backup/backup.admin.php
@@ -41,6 +41,8 @@ class BackupAdmin extends Backend
                     Notification::set('error', __('Backup was not created', 'backup'));
                 }
 
+                Request::redirect(Option::get('siteurl').'/admin/index.php?id=backup');
+
             } else { die('Request was denied because it contained an invalid security token. Please refresh the page and try again.'); }
         }
 


### PR DESCRIPTION
Ошибка была в том, что Notification'ы обрабатывались раньше, чем их устанавливали. Необходим редирект, как и в других действиях (удаление, восстановление).
