### PR TITLE
Delete quotes in shortcut's parameters

### DIFF
--- a/engine/Shortcode.php
+++ b/engine/Shortcode.php
@@ -154,6 +154,10 @@ class Shortcode
                 }
             }
         }
+        
+        foreach ($attributes as &$attr) {
+			$attr = str_replace(['&quot;', '"', "'"], '', $attr);
+        }
 
         // Check if this shortcode realy exists then call user function else return empty string
         return (isset(Shortcode::$shortcode_tags[$shortcode])) ? $prefix . call_user_func(Shortcode::$shortcode_tags[$shortcode], $attributes, $matches[5], $shortcode) . $suffix : '';


### PR DESCRIPTION
It will improve compatability with some editors (e.g. CKEditor)
