### PR TITLE
Allow renaming of admin folder for better security. #369

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -11,10 +11,18 @@
  * file that was distributed with this source code.
  */
 
+/** 
+ * Define __DIR__ constant for PHP 5.2.x
+ */
+if ( ! defined('__DIR__')) {
+    define('__DIR__', dirname(__FILE__));
+}
+
 
 // Main engine defines
 define('DS', DIRECTORY_SEPARATOR);
-define('ROOT', rtrim(str_replace(array('admin'), array(''), dirname(__FILE__)), '\\/'));
+define('ROOT', rtrim(dirname(__DIR__), '\\/')); // eg '/home/user/public_html'
+define('ADMIN', basename(__DIR__)); // eg 'admin'
 define('BACKEND', true);
 define('MONSTRA_ACCESS', true);
 
@@ -131,7 +139,7 @@ if (Request::post('reset_password_submit')) {
         Notification::set('reset_password', 'reset_password');
 
         // Redirect to password-reset page
-        Request::redirect(Site::url().'/admin');
+        Request::redirect(Site::url().'/'.ADMIN.'');
     }
 
     Notification::setNow('reset_password', 'reset_password');

--- a/admin/themes/default/index.template.php
+++ b/admin/themes/default/index.template.php
@@ -21,7 +21,7 @@
     <?php Stylesheet::add('public/assets/css/chocolat.css', 'backend', 2); ?>
     <?php Stylesheet::add('public/assets/css/bootstrap-fileupload.css', 'backend', 3); ?>
     <?php Stylesheet::add('public/assets/css/icheck-blue.css', 'backend', 4); ?>
-    <?php Stylesheet::add('admin/themes/default/css/default.css', 'backend', 5); ?>
+    <?php Stylesheet::add(ADMIN.'/themes/default/css/default.css', 'backend', 5); ?>
     <?php Stylesheet::load(); ?>
 
     <!-- JavaScripts -->
@@ -31,7 +31,7 @@
     <script src="<?php echo Site::url(); ?>/public/assets/js/icheck.min.js"></script>    
     <?php Javascript::add('public/assets/js/jquery.chocolat.js', 'backend', 3); ?>
     <?php Javascript::add('public/assets/js/bootstrap-fileupload.js', 'backend', 4); ?>
-    <?php Javascript::add('admin/themes/default/js/default.js', 'backend', 5); ?>
+    <?php Javascript::add(ADMIN.'/themes/default/js/default.js', 'backend', 5); ?>
     <?php Javascript::load(); ?>
 
     <?php Action::run('admin_header'); ?>
@@ -74,12 +74,12 @@
               <span class="icon-bar"></span>
               <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="<?php echo Site::url(); ?>/admin/index.php?id=dashboard">MONSTRA</a>
+            <a class="navbar-brand" href="<?php echo Site::url().'/'.ADMIN; ?>/index.php?id=dashboard">MONSTRA</a>
           </div>
 
           <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">      
             <ul class="nav navbar-nav">          
-              <li<?php if (Request::get('id') == 'dashboard') { ?> class="active"<?php } ?>><a href="<?php echo Site::url(); ?>/admin/index.php?id=dashboard"><?php echo __('Dashboard', 'dashboard'); ?></a></li>              
+              <li<?php if (Request::get('id') == 'dashboard') { ?> class="active"<?php } ?>><a href="<?php echo Site::url().'/'.ADMIN; ?>/index.php?id=dashboard"><?php echo __('Dashboard', 'dashboard'); ?></a></li>              
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown"><?php echo __('Content', 'pages'); ?> <b class="caret"></b></a>
                 <ul class="dropdown-menu">
@@ -117,8 +117,8 @@
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown"><?php echo Session::get('user_login'); ?> <img src="<?php echo Users::getGravatarURL(Session::get('user_email'), 28); ?>" alt=""> <b class="caret"></b></a>
                 <ul class="dropdown-menu">
-                  <li><a href="<?php echo Site::url(); ?>/admin/index.php?id=users&action=edit&user_id=<?php echo Session::get('user_id'); ?>"><?php echo __('Profile', 'users')?></a></li>
-                  <li><a href="<?php echo Site::url(); ?>/admin/?logout=do"><?php echo __('Log Out', 'users'); ?></a></li>              
+                  <li><a href="<?php echo Site::url().'/'.ADMIN; ?>/index.php?id=users&action=edit&user_id=<?php echo Session::get('user_id'); ?>"><?php echo __('Profile', 'users')?></a></li>
+                  <li><a href="<?php echo Site::url().'/'.ADMIN; ?>/?logout=do"><?php echo __('Log Out', 'users'); ?></a></li>              
                 </ul>
               </li>
             </ul>        

--- a/admin/themes/default/login.template.php
+++ b/admin/themes/default/login.template.php
@@ -14,7 +14,7 @@
         <link rel="stylesheet" href="<?php echo Site::url(); ?>/public/assets/css/messenger-theme-flat.css" type="text/css" />
         <?php Stylesheet::add('public/assets/css/bootstrap-lightbox.css', 'backend', 2); ?>
         <?php Stylesheet::add('public/assets/css/bootstrap-fileupload.css', 'backend', 3); ?>
-        <?php Stylesheet::add('admin/themes/default/css/default.css', 'backend', 5); ?>
+        <?php Stylesheet::add(ADMIN.'/themes/default/css/default.css', 'backend', 5); ?>
         <?php Stylesheet::load(); ?>
 
         <!-- JavaScripts -->
@@ -24,7 +24,7 @@
         <script src="<?php echo Site::url(); ?>/public/assets/js/messenger-theme-flat.js"></script>        
         <?php Javascript::add('public/assets/js/bootstrap-lightbox.js', 'backend', 3); ?>
         <?php Javascript::add('public/assets/js/bootstrap-fileupload.js', 'backend', 4); ?>
-        <?php Javascript::add('admin/themes/default/js/default.js', 'backend', 5); ?>
+        <?php Javascript::add(ADMIN.'/themes/default/js/default.js', 'backend', 5); ?>
         <?php Javascript::load(); ?>
 
         <script type="text/javascript">
@@ -68,7 +68,7 @@
 
         <div class="container form-signin">
 
-            <div class="text-center"><a class="brand" href="<?php echo Option::get('siteurl'); ?>/admin"><img src="<?php echo Option::get('siteurl'); ?>/public/assets/img/monstra-logo-256px.png" alt="monstra" /></a></div>
+            <div class="text-center"><a class="brand" href="<?php echo Option::get('siteurl').'/'.ADMIN; ?>"><img src="<?php echo Option::get('siteurl'); ?>/public/assets/img/monstra-logo-256px.png" alt="monstra" /></a></div>
             <div class="administration-area well">
                 <div>
                     <form method="post">

--- a/boot/defines.php
+++ b/boot/defines.php
@@ -12,7 +12,9 @@ define('THEMES_SITE', ROOT . DS . 'public' . DS . 'themes');
 /**
  * The filesystem path to the admin 'themes' folder
  */
-define('THEMES_ADMIN', ROOT . DS . 'admin' . DS . 'themes');
+if (!defined('ADMIN'))
+	define('ADMIN', 'admin'); // change this if you use the members area in the front webite
+define('THEMES_ADMIN', ROOT . DS . 'admin' . DS . 'themes'); 
 
 /**
  * The filesystem path to the 'plugins' folder

--- a/boot/defines.php
+++ b/boot/defines.php
@@ -13,8 +13,8 @@ define('THEMES_SITE', ROOT . DS . 'public' . DS . 'themes');
  * The filesystem path to the admin 'themes' folder
  */
 if (!defined('ADMIN'))
-	define('ADMIN', 'admin'); // change this if you use the members area in the front webite
-define('THEMES_ADMIN', ROOT . DS . 'admin' . DS . 'themes'); 
+	define('ADMIN', 'admin'); // change this if you use the members area in the front website
+define('THEMES_ADMIN', ROOT . DS . ADMIN . DS . 'themes'); 
 
 /**
  * The filesystem path to the 'plugins' folder

--- a/engine/Monstra.php
+++ b/engine/Monstra.php
@@ -263,6 +263,11 @@ class Monstra
         } else {
             throw new RuntimeException("The defines file does not exist.");
         }
+        
+        // a last gasp catch-all to ensure that any front-end systems won't cause an exception, but will simply fail to use the correct URL
+        // (This is normally in defines.php)
+        if (!defined('ADMIN')) 
+            define('ADMIN', 'admin'); 
     }
 
     /**

--- a/engine/Plugin/Stylesheet.php
+++ b/engine/Plugin/Stylesheet.php
@@ -139,7 +139,7 @@ class Stylesheet
                                  '@theme_admin_url'),
                            array(Option::get('siteurl'),
                                  Option::get('siteurl').'/public/themes/'.Option::get('theme_site_name'),
-                                 Option::get('siteurl').'/admin/themes/'.Option::get('theme_admin_name')),
+                                 Option::get('siteurl').'/'.ADMIN.'/themes/'.Option::get('theme_admin_name')),
                            $frontend_buffer);
     }
 

--- a/install.php
+++ b/install.php
@@ -168,7 +168,7 @@
         <link rel="icon" href="<?php echo $site_url; ?>/favicon.ico" type="image/x-icon" />
         <link rel="shortcut icon" href="<?php echo $site_url; ?>/favicon.ico" type="image/x-icon" />
         <link rel="stylesheet" href="<?php echo $site_url; ?>/public/assets/css/bootstrap.css" media="all" type="text/css" />
-        <link rel="stylesheet" href="<?php echo $site_url; ?>/admin/themes/default/css/default.css" media="all" type="text/css" />
+        <link rel="stylesheet" href="<?php echo $site_url.'/'.ADMIN; ?>/themes/default/css/default.css" media="all" type="text/css" />
 
         <style>
 

--- a/plugins/box/backup/backup.admin.php
+++ b/plugins/box/backup/backup.admin.php
@@ -41,7 +41,7 @@ class BackupAdmin extends Backend
                     Notification::set('error', __('Backup was not created', 'backup'));
                 }
 
-                Request::redirect(Option::get('siteurl').'/admin/index.php?id=backup');
+                Request::redirect(Option::get('siteurl').'/'.ADMIN.'/index.php?id=backup');
 
             } else { die('Request was denied because it contained an invalid security token. Please refresh the page and try again.'); }
         }
@@ -58,7 +58,7 @@ class BackupAdmin extends Backend
                     Notification::set('error', __('Backup was not deleted', 'backup'));
                 }
                 
-                Request::redirect(Option::get('siteurl').'/admin/index.php?id=backup');
+                Request::redirect(Option::get('siteurl').'/'.ADMIN.'/index.php?id=backup');
 
             } else { die('Request was denied because it contained an invalid security token. Please refresh the page and try again.'); }
         }
@@ -91,7 +91,7 @@ class BackupAdmin extends Backend
                     Notification::set('error', __('Backup was not restored', 'backup'));
                 }
 
-                Request::redirect(Option::get('siteurl').'/admin/index.php?id=backup');
+                Request::redirect(Option::get('siteurl').'/'.ADMIN.'/index.php?id=backup');
 
             } else { die('Request was denied because it contained an invalid security token. Please refresh the page and try again.'); }
         }

--- a/plugins/box/backup/views/backend/index.view.php
+++ b/plugins/box/backup/views/backend/index.view.php
@@ -31,7 +31,7 @@
     <tr>
         <td>
             <?php $name = strtotime(str_replace('-', '', basename($backup, '.zip'))); ?>
-            <?php echo Html::anchor(Date::format($name, 'F jS, Y - g:i A'), Option::get('siteurl').'/admin/index.php?id=backup&download='.$backup.'&token='.Security::token()); ?>
+            <?php echo Html::anchor(Date::format($name, 'F jS, Y - g:i A'), Option::get('siteurl').'/'.ADMIN.'/index.php?id=backup&download='.$backup.'&token='.Security::token()); ?>
         </td>
         <td class="visible-lg hidden-xs"><?php echo Number::byteFormat(filesize(ROOT . DS . 'backups' . DS . $backup)); ?></td>
         <td>

--- a/plugins/box/filesmanager/filesmanager.admin.php
+++ b/plugins/box/filesmanager/filesmanager.admin.php
@@ -36,25 +36,25 @@ class FilesmanagerAdmin extends Backend
         // Add slash if not exists
         if (substr($path, -1, 1) != '/') {
             $path .= '/';
-            Request::redirect($site_url.'/admin/index.php?id=filesmanager&path='.$path);
+            Request::redirect($site_url.'/'.ADMIN.'/index.php?id=filesmanager&path='.$path);
         }
 
         // Upload corectly!
         if ($path == 'uploads' || $path == 'uploads//') {
             $path = 'uploads/';
-            Request::redirect($site_url.'/admin/index.php?id=filesmanager&path='.$path);
+            Request::redirect($site_url.'/'.ADMIN.'/index.php?id=filesmanager&path='.$path);
         }
 
         // Only 'uploads' folder!
         if (strpos($path, 'uploads') === false) {
             $path = 'uploads/';
-            Request::redirect($site_url.'/admin/index.php?id=filesmanager&path='.$path);
+            Request::redirect($site_url.'/'.ADMIN.'/index.php?id=filesmanager&path='.$path);
         }
 
         // Set default path value if path is empty
         if ($path == '') {
             $path = 'uploads/';
-            Request::redirect($site_url.'/admin/index.php?id=filesmanager&path='.$path);
+            Request::redirect($site_url.'/'.ADMIN.'/index.php?id=filesmanager&path='.$path);
         }
 
         $files_path = ROOT . DS . 'public' . DS . $path;
@@ -73,7 +73,7 @@ class FilesmanagerAdmin extends Backend
                 } else {
                     Notification::set('error', __('File was not deleted', 'filesmanager'));
                 }
-                Request::redirect($site_url.'/admin/index.php?id=filesmanager&path='.$path);
+                Request::redirect($site_url.'/'.ADMIN.'/index.php?id=filesmanager&path='.$path);
 
             } else { die('Request was denied because it contained an invalid security token. Please refresh the page and try again.'); }
         }
@@ -92,7 +92,7 @@ class FilesmanagerAdmin extends Backend
                     Notification::set('error', __('Directory was not deleted', 'filesmanager'));
                 }
                 
-                Request::redirect($site_url.'/admin/index.php?id=filesmanager&path='.$path);
+                Request::redirect($site_url.'/'.ADMIN.'/index.php?id=filesmanager&path='.$path);
                 
                     
             } else { die('Request was denied because it contained an invalid security token. Please refresh the page and try again.'); }
@@ -111,7 +111,7 @@ class FilesmanagerAdmin extends Backend
 
                 if (empty($rename_to)) {
                     Notification::set('error', __('Can not be empty', 'filesmanager'));
-                    Request::redirect($site_url.'/admin/index.php?id=filesmanager&path='.$path);
+                    Request::redirect($site_url.'/'.ADMIN.'/index.php?id=filesmanager&path='.$path);
                 }
 
                 $ext = ($rename_type === 'file') ? '.'. File::ext($rename_from) : '';
@@ -119,12 +119,12 @@ class FilesmanagerAdmin extends Backend
 
                 if (is_dir($rename_to)) {
                     Notification::set('error', __('Directory exists', 'filesmanager'));
-                    Request::redirect($site_url.'/admin/index.php?id=filesmanager&path='.$path);
+                    Request::redirect($site_url.'/'.ADMIN.'/index.php?id=filesmanager&path='.$path);
                 }
 
                 if (is_file($rename_to)) {
                     Notification::set('error', __('File exists', 'filesmanager'));
-                    Request::redirect($site_url.'/admin/index.php?id=filesmanager&path='.$path);
+                    Request::redirect($site_url.'/'.ADMIN.'/index.php?id=filesmanager&path='.$path);
                 }
 
                 $success = rename($files_path.$rename_from, $rename_to);
@@ -134,7 +134,7 @@ class FilesmanagerAdmin extends Backend
                 } else {
                     Notification::set('error', __('Failure', 'filesmanager'));
                 }
-                Request::redirect($site_url.'/admin/index.php?id=filesmanager&path='.$path);
+                Request::redirect($site_url.'/'.ADMIN.'/index.php?id=filesmanager&path='.$path);
 
             } else { die('Request was denied because it contained an invalid security token. Please refresh the page and try again.'); }
         }
@@ -169,7 +169,7 @@ class FilesmanagerAdmin extends Backend
                 if (Request::post('dragndrop')) {
                     Request::shutdown();
                 } else {
-                    Request::redirect($site_url.'/admin/index.php?id=filesmanager&path='.$path);
+                    Request::redirect($site_url.'/'.ADMIN.'/index.php?id=filesmanager&path='.$path);
                 }
             } else { die('Request was denied because it contained an invalid security token. Please refresh the page and try again.'); }
         }
@@ -239,7 +239,7 @@ class FilesmanagerAdmin extends Backend
                 ->assign('upload_max_filesize', FilesmanagerAdmin::uploadSize())
                 ->assign('files_path', $files_path)
                 ->assign('fileuploader', array(
-                    'uploadUrl' => $site_url.'/admin/index.php?id=filesmanager&path='.$path,
+                    'uploadUrl' => $site_url.'/'.ADMIN.'/index.php?id=filesmanager&path='.$path,
                     'csrf'      => Security::token(),
                     'errorMsg'  => __('Upload server error', 'filesmanager')
                 ))->display();

--- a/plugins/box/information/views/backend/index.view.php
+++ b/plugins/box/information/views/backend/index.view.php
@@ -121,8 +121,8 @@
                         <td><?php if (Dir::writable(PLUGINS)) { ?><span class="badge badge-success"><?php echo __('Writable', 'information'); ?></span><?php } else { ?><span class="badge badge-error"><?php echo __('Unwritable', 'information'); ?></span><?php } ?></td>
                     </tr>
                     <tr>
-                        <td><?php echo ROOT . DS . 'admin' ?></td>
-                        <td><?php if (Dir::writable(ROOT . DS . 'admin')) { ?><span class="badge badge-success"><?php echo __('Writable', 'information'); ?></span><?php } else { ?><span class="badge badge-error"><?php echo __('Unwritable', 'information'); ?></span><?php } ?></td>
+                        <td><?php echo ROOT . DS . ADMIN ?></td>
+                        <td><?php if (Dir::writable(ROOT . DS . ADMIN)) { ?><span class="badge badge-success"><?php echo __('Writable', 'information'); ?></span><?php } else { ?><span class="badge badge-error"><?php echo __('Unwritable', 'information'); ?></span><?php } ?></td>
                     </tr>
                 </tbody>
             </table>
@@ -150,6 +150,19 @@
                         <tr>
                             <td><span class="badge badge-error" style="padding-left:5px; padding-right:5px;"><b>!</b></span> </td>
                             <td><?php echo __('The Monstra index.php file has been found to be writable. We would advise you to remove all write permissions. <br>You can do this on unix systems with: <code>chmod a-w :path</code>', 'information', array(':path' => ROOT . DS . 'index.php')); ?></td>
+                        </tr>
+                    <?php } ?>
+                    <?php if (Dir::exists(ROOT . DS . 'admin')) { 
+                        $new_admin = 'admin' . bin2hex(openssl_random_pseudo_bytes(2));
+                        ?>
+                        <tr>
+                            <td><span class="badge badge-error" style="padding-left:5px; padding-right:5px;"><b>!</b></span> </td>
+                            <td><?php echo __('The Monstra admin folder should be renamed to something else. We suggest <code>:name</code> or something memorable.<br>You can rename the folder on unix systems with: <code>mv :pathadmin :path:name</code> <br> You will then access this admin website via <code>:url</code><br><br>You may also need to update <code>:defines</code> by adding <code>:newdefine</code>, particularly if you have a members area.', 'information', 
+                                array(':path' => ROOT . DS, 
+                                    ':name' => $new_admin, 
+                                    ':url' => Option::get('siteurl').'/'.$new_admin, 
+                                    ':defines' => ROOT . DS . 'boot' . DS . 'defines.php',
+                                    ':newdefine' => 'if (!defined(\'ADMIN\')) define(\'ADMIN\', \''.$new_admin.'\');')); ?></td>
                         </tr>
                     <?php } ?>
                     <?php if (Monstra::$environment == Monstra::DEVELOPMENT) { ?>

--- a/plugins/box/pages/views/backend/index.view.php
+++ b/plugins/box/pages/views/backend/index.view.php
@@ -109,5 +109,5 @@
 </div>
 
 <form>
-    <input type="hidden" name="url" value="<?php echo Option::get('siteurl'); ?>/admin/index.php?id=pages">
+    <input type="hidden" name="url" value="<?php echo Option::get('siteurl').'/'.ADMIN; ?>/index.php?id=pages">
 </form>

--- a/plugins/box/plugins/plugins.admin.php
+++ b/plugins/box/plugins/plugins.admin.php
@@ -174,7 +174,7 @@ class PluginsAdmin extends Backend
                 if (Request::post('dragndrop')) {
                     Request::shutdown();
                 } else {
-                    Request::redirect($site_url.'/admin/index.php?id=plugins#installnew');
+                    Request::redirect($site_url.'/'.ADMIN.'/index.php?id=plugins#installnew');
                 }
             } else { die('Request was denied because it contained an invalid security token. Please refresh the page and try again.'); }
         }
@@ -219,7 +219,7 @@ class PluginsAdmin extends Backend
                 ->assign('plugins_to_intall', $plugins_to_intall)
                 ->assign('_users_plugins', $_users_plugins)
                 ->assign('fileuploader', array(
-                    'uploadUrl' => $site_url.'/admin/index.php?id=plugins',
+                    'uploadUrl' => $site_url.'/'.ADMIN.'/index.php?id=plugins',
                     'csrf'      => Security::token(),
                     'errorMsg'  => __('Upload server error', 'filesmanager')
                 ))

--- a/plugins/box/plugins/views/backend/index.view.php
+++ b/plugins/box/plugins/views/backend/index.view.php
@@ -152,7 +152,7 @@
             $.ajax({
                 type:"post",
                 data:"readme_plugin="+$(this).attr('readme_plugin'),
-                url: "<?php echo Site::url(); ?>/admin/index.php?id=plugins",
+                url: "<?php echo Site::url().'/'.ADMIN; ?>/index.php?id=plugins",
                 success: function(data){
                     $('#readme .modal-body').html(data);
                 }

--- a/plugins/box/themes/themes.plugin.php
+++ b/plugins/box/themes/themes.plugin.php
@@ -40,11 +40,16 @@ class Themes
     {
         $themes_folders = array();
 
+        $themes_dir = THEMES_ADMIN;
+        if (ADMIN!='admin' && THEMES_ADMIN==ROOT . DS . 'admin' . DS . 'themes')
+            // admin folder changed, but not the THEMES_ADMIN definition
+            $themes_dir = ROOT . DS . ADMIN . DS . 'themes';
+
         // Get all themes folders
-        $_themes_admin_folders = Dir::scan(THEMES_ADMIN);
+        $_themes_admin_folders = Dir::scan($themes_dir);
 
         // Create an array of valid themes folders
-        foreach($_themes_admin_folders as $folder) if (File::exists(THEMES_ADMIN . DS . $folder . DS . 'index.template.php')) $__themes_admin_folders[] = $folder;
+        foreach($_themes_admin_folders as $folder) if (File::exists($themes_dir . DS . $folder . DS . 'index.template.php')) $__themes_admin_folders[] = $folder;
         foreach($__themes_admin_folders as $theme) $themes[$theme] = $theme;
 
         return $themes;

--- a/plugins/box/users/views/frontend/profile.view.php
+++ b/plugins/box/users/views/frontend/profile.view.php
@@ -12,7 +12,7 @@
 <?php if (Users::isLoged()) { ?>
 <br>
 <a href="<?php echo Site::url(); ?>/users/<?php echo $user['id']; ?>/edit"><?php echo __('Edit profile', 'users'); ?></a> /
-<?php if (in_array(Session::get('user_role'), array('admin', 'editor'))) { ?> <a href="<?php echo Site::url(); ?>/admin"><?php echo __('Administration', 'system'); ?></a> / <?php } ?>
+<?php if (in_array(Session::get('user_role'), array('admin', 'editor'))) { ?> <a href="<?php echo Site::url().'/'.ADMIN; ?>"><?php echo __('Administration', 'system'); ?></a> / <?php } ?>
 <a href="<?php echo Site::url(); ?>/users/logout"><?php echo __('Log Out', 'users'); ?></a>
 <?php } ?>
 <?php } else { echo __('This users doesnt exists', 'users'); } ?>

--- a/plugins/box/users/views/frontend/userspanel.view.php
+++ b/plugins/box/users/views/frontend/userspanel.view.php
@@ -4,7 +4,7 @@
         <ul class="dropdown-menu">
             <li><a href="<?php echo Site::url(); ?>/users/<?php echo Session::get('user_id'); ?>"><?php echo __('Profile', 'users'); ?></a></li>
             <?php if (in_array(Session::get('user_role'), array('admin', 'editor'))) { ?>
-                <li><a href="<?php echo Site::url(); ?>/admin"><?php echo __('Administration', 'system'); ?></a></li>
+                <li><a href="<?php echo Site::url().'/'.ADMIN; ?>"><?php echo __('Administration', 'system'); ?></a></li>
             <?php } ?>
             <li><a href="<?php echo Site::url(); ?>/users/logout"><?php echo __('Log Out', 'users'); ?></a></li>
         </ul>


### PR DESCRIPTION
As part of general website security, these changes can be incorporated as part of #369.

Despite a lot of file changes, most simply change the hard-coded 'admin' folder to use a new global constant 'ADMIN'. This ADMIN constant is automatically calculated when using the backend interface (see admin/index.php), and should be manually added to defines.php if needed for user management in the front end.

The only issues beyond this were:

1. The constant THEMES_ADMIN is problematic, so code in plugins/box/themes.plugin.php detects a default THEMES_ADMIN value and quietly ignores it. This ensures existing installs won't break without change.
2. Using the 'members area' login/logout in the frontend, definitively requires the ADMIN constant to be defined. In case an existing install does not define ADMIN in defines.php, it is detected in Monstra::loadDefines() and defined there, so that things won't crash (but may cause 404's)

The Information > Security tab has been updated to describe the actions an admininstrator needs to take (rename admin folder and add ADMIN to defines.php). See screenshot below

![monstra-admin-rename](https://cloud.githubusercontent.com/assets/15967/12370691/8b06442c-bc6e-11e5-8214-ded7fb726bbe.png)
