### PR TITLE
changed minified URIs to eliminate query strings

### DIFF
--- a/engine/Plugin/Javascript.php
+++ b/engine/Plugin/Javascript.php
@@ -59,7 +59,7 @@ class Javascript
     public static function load()
     {
         $backend_site_js_path  = MINIFY . DS . 'backend_site.minify.js';
-        $frontend_site_js_path = MINIFY . DS . 'frontend_site.minify.js';
+        $frontend_site_js_path = MINIFY . DS . 'frontend_site.minify.'.Option::get('javascript_version').'.js';
 
         // Load javascripts
         if (count(Javascript::$javascripts) > 0) {
@@ -122,7 +122,7 @@ class Javascript
             if (BACKEND) {
                 echo '<script type="text/javascript" src="'.Option::get('siteurl').'/tmp/minify/backend_site.minify.js?'.Option::get('javascript_version').'"></script>';
             } else {
-                echo '<script type="text/javascript" src="'.Option::get('siteurl').'/tmp/minify/frontend_site.minify.js?'.Option::get('javascript_version').'"></script>'."\n";
+                echo '<script type="text/javascript" src="'.Option::get('siteurl').'/tmp/minify/frontend_site.minify.'.Option::get('javascript_version').'.js"></script>'."\n";
             }
         }
     }

--- a/engine/Plugin/Stylesheet.php
+++ b/engine/Plugin/Stylesheet.php
@@ -59,7 +59,7 @@ class Stylesheet
     public static function load()
     {
         $backend_site_css_path  = MINIFY . DS . 'backend_site.minify.css';
-        $frontend_site_css_path = MINIFY . DS . 'frontend_site.minify.css';
+        $frontend_site_css_path = MINIFY . DS . 'frontend_site.minify.'.Option::get('styles_version').'.css';
 
         // Load stylesheets
         if (count(Stylesheet::$stylesheets) > 0) {
@@ -124,7 +124,7 @@ class Stylesheet
             if (BACKEND) {
                 echo '<link rel="stylesheet" href="'.Option::get('siteurl').'/tmp/minify/backend_site.minify.css?'.Option::get('styles_version').'" type="text/css" />';
             } else {
-                echo '<link rel="stylesheet" href="'.Option::get('siteurl').'/tmp/minify/frontend_site.minify.css?'.Option::get('styles_version').'" type="text/css" />'."\n";
+                echo '<link rel="stylesheet" href="'.Option::get('siteurl').'/tmp/minify/frontend_site.minify.'.Option::get('styles_version').'.css" type="text/css" />'."\n";
             }
         }
     }


### PR DESCRIPTION
I make this change on all my installs. It improves PageSpeed metrics and I don't see any downside. 

For some reasoning, see [this article](http://www.stevesouders.com/blog/2008/08/23/revving-filenames-dont-use-querystring/) which is referenced in HTML5 Boilerplate's standard .htaccess 